### PR TITLE
Add stream support

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,9 @@ async function getResponse(request, config) {
       case "formData":
         response.data = await stageOne.formData();
         break;
+      case "stream":
+        response.data = stageOne.body;
+        break;
       default:
         response.data = await stageOne.text();
         break;


### PR DESCRIPTION
I added a case for stream which returns the stream from the fetch response. The stream returned is unfortunately a web browser version of a stream not a nodejs stream and will not be compatible with existing axios code that was written for server side applications or existing examples for axios streams. But axios currently doesn't support any streams in the web browser. The wrong type is better than an error. Let me know what you think.